### PR TITLE
Fix backspace key handling

### DIFF
--- a/src/gfile.c
+++ b/src/gfile.c
@@ -501,20 +501,17 @@ void editstring(char *buffer, int maxlength)
 {
   int len = strlen(buffer);
 
-  if (key)
+  if ((key >= 32) && (key < 256))
   {
-    if ((key >= 32) && (key < 256))
+    if (len < maxlength-1)
     {
-      if (len < maxlength-1)
-      {
-        buffer[len] = key;
-        buffer[len+1] = 0;
-      }
+      buffer[len] = key;
+      buffer[len+1] = 0;
     }
-    if ((key == 8) && (len > 0))
-    {
-      buffer[len-1] = 0;
-    }
+  }
+  if ((rawkey == KEY_BACKSPACE) && (len > 0))
+  {
+    buffer[len-1] = 0;
   }
 }
 

--- a/src/gpattern.c
+++ b/src/gpattern.c
@@ -126,7 +126,7 @@ void patterncommands(GTOBJECT *gt, int midiNote)
 
 
 		if (newnote > LASTNOTE) newnote = -1;
-		if ((jrawkey == 0x08) && (!editorInfo.epcolumn)) newnote = REST;
+		if ((jrawkey == KEY_BACKSPACE) && (!editorInfo.epcolumn)) newnote = REST;
 		if ((jrawkey == 0x14) && (!editorInfo.epcolumn)) newnote = KEYOFF;
 		if (jrawkey == KEY_ENTER)
 		{


### PR DESCRIPTION
Sorry, forgot a couple of commits in the SDL2 port to fix the handling of backspace key in info and pattern editors.