### PR TITLE
Fix some format warnings

### DIFF
--- a/src/ginfo.c
+++ b/src/ginfo.c
@@ -449,7 +449,7 @@ void displayPatternInfo(GTOBJECT *gt)
 				sprintf(infoTextBuffer, "Channel Tempo: %02X", (data - 0x80));
 		}
 		else
-			sprintf(infoTextBuffer, patternInstructionInfoString[instr]);
+			sprintf(infoTextBuffer, "%s", patternInstructionInfoString[instr]);
 	}
 	else
 		sprintf(infoTextBuffer, "                                ");

--- a/src/gt2stereo.c
+++ b/src/gt2stereo.c
@@ -867,14 +867,14 @@ void waitkeymouse(GTOBJECT *gt)
 						else
 						{
 							sprintf(&keyOffsetText[0], "                        ");
-							sprintf(infoTextBuffer, keyOffsetText);
+							sprintf(infoTextBuffer, "%s", keyOffsetText);
 						}
 					}
 				}
 				else
 				{
 					calculateNoteOffsets();
-					sprintf(infoTextBuffer, keyOffsetText);
+					sprintf(infoTextBuffer, "%s", keyOffsetText);
 				}
 			}
 		}


### PR DESCRIPTION
Fixes: `format not a string literal and no format arguments [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wformat-security-Werror=format-security8;;]`