### PR TITLE
fix: #76 setPaletteName heap overflow + Linux ASan/UBSan gate

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -40,3 +40,42 @@ jobs:
 
       - name: Run smoke tests
         run: bash tests/integration/smoke.sh linux/ ""
+
+  # ASan/UBSan gate. Reproduces the class of bug behind issue #76 (heap buffer
+  # overflow in setPaletteName) with a symbolized report and fails the build on it.
+  # Linux only: MinGW GCC ships no libasan, and macOS does not exercise the startup
+  # overflow path (see tests/docs/handover-issue-76.md). Builds with SANITIZE=1
+  # (adds -fsanitize=address,undefined, disables FORTIFY, skips strip).
+  asan:
+    name: Linux ASan/UBSan
+    runs-on: ubuntu-latest
+    env:
+      SDL_VIDEODRIVER: dummy
+      # detect_leaks=0: the editor/tools never free globals -> LSan would flood the run
+      # with benign leaks and break the CLI usage exit-code checks. abort_on_error=1 so a
+      # real error aborts (smoke.sh flags exit 134 and greps the sanitizer output).
+      ASAN_OPTIONS: detect_leaks=0:abort_on_error=1
+      UBSAN_OPTIONS: print_stacktrace=1
+      # Scope this gate to the gtultra startup path (where #76 lives). SKIP_USAGE avoids
+      # the CLI usage checks, which under ASan trip a *separate* pre-existing bug
+      # (global-buffer-overflow in clearsong, gsong.c:1703 - see tests/docs/known-bugs.md).
+      # Widen coverage in the follow-up that fixes that bug.
+      SKIP_USAGE: 1
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install dependencies
+        run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+          sudo apt-get update
+          sudo apt-get install -y build-essential gcc-16 g++-16 libsdl2-dev libsdl2-ttf-dev libasound2-dev
+
+      - name: Build (ASan/UBSan)
+        run: make linux-rebuild SANITIZE=1
+        env:
+          CC: gcc-16
+          CXX: g++-16
+
+      - name: Run smoke tests (sanitized)
+        run: bash tests/integration/smoke.sh linux/ ""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.7] - 2026-07-13
+
 ### Added
 
 - GitHub Actions release workflow (`workflow_dispatch`) with version/overwrite inputs, per-platform builds (Linux x86_64 + aarch64, macOS arm64, Windows x86_64), Windows runtime DLL bundling, source archive, and SHA256 checksums; pre-releases are auto-detected from a `-rc` tag suffix (no separate input)
 - Linux `aarch64` build leg in CI (`build-linux.yml`), matrixed alongside `x86_64` on native ARM runners
+- `SANITIZE=1` build switch in `src/makefile.common` (`make <plat>-build SANITIZE=1`): adds `-fsanitize=address,undefined` to compile and link, disables `_FORTIFY_SOURCE`, and skips `strip` for symbolized reports
+- Linux ASan/UBSan CI job (`.github/workflows/build-linux.yml`) that builds with `SANITIZE=1` and runs the startup smoke test; a regression gate for the issue #76 class of memory bug (Linux only: MinGW GCC has no libasan and macOS does not exercise the startup path)
 - Cross-platform `goatdata.c` determinism gate: `tests/integration/check-goatdata.sh` compares the regenerated player data against the committed reference `tests/goatdata.sha256`, wired into all three build workflows (confirmed byte-identical on Linux/macOS/Windows)
 - `.gitattributes` enforcing LF on packed player inputs (`*.s`, `*.seq`, `*.gtp`) and binary handling for packed resources, so generation is identical on every OS
 - `CLAUDE.md` agent guide (index of key files and rules) with `AGENTS.md` as a symlink to it
-- Project knowledge base under `tests/docs/`: `build-determinism.md`, `testing-strategy.md`, `known-bugs.md`, `handover-issue-76.md`
+- Project knowledge base under `tests/docs/`: `build-determinism.md`, `testing-strategy.md`, `known-bugs.md`, `handover-issue-76.md`, and follow-up pick-up docs `handover-unused-result.md`, `handover-gt2reloc-bug2.md`, `handover-unit-tests.md`
 
 ### Changed
 
 - Linux CI build now uses GCC 16 (via `ubuntu-toolchain-r/test` PPA), superseding GCC 15
+- `tests/integration/smoke.sh` now treats a startup `SIGABRT` (exit 134) and any ASan/UBSan/FORTIFY diagnostic as a crash (previously only `139`/`138`), closing the gap that let issue #76 pass CI
 
 ### Fixed
 
+- Heap buffer overflow in `setPaletteName()` (`src/gpaletteeditor.c`) that crashed GTUltra at startup under glibc FORTIFY (`*** buffer overflow detected ***`, issue #76): `malloc(strlen(...))` + `strcpy` (one byte short of the NUL) replaced with `strdup`. Fix by @fgaz (PR #73); reported and root-caused by @lunadog (#76)
+- `-Wformat-security` warnings from non-literal `sprintf` format strings at `src/gt2stereo.c:1198`, `:1205` and `src/ginfo.c:469`, now `sprintf(buf, "%s", ...)`. Thanks @OPNA2608 (PR #22)
 - `src/bme/dat2inc.c` now writes `goatdata.c` in binary mode (`"wt"` → `"wb"`) so the generated file is byte-identical (LF) across Linux, macOS, and Windows
 
 ## [1.5.6] - 2026-07-10

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,8 @@ C64 SID tracker (GoatTracker Stereo fork). ~32k LOC own logic; rest vendored/gen
 - Build determinism + `goatdata.c` rules: `tests/docs/build-determinism.md`
 - Known bugs / fixes: `tests/docs/known-bugs.md`
 - Testing strategy: `tests/docs/testing-strategy.md`
+- Handover / follow-ups: `tests/docs/handover-*.md` (issue-76, unused-result, gt2reloc-bug2, unit-tests, asm-pointer-cast)
+- Compiler warnings inventory: `tests/docs/warnings-tracking.md`
 - Main app (`gtultra`): `src/gt2stereo.c`; app logic: `src/g*.c`
 - CLI tools: `src/{gt2reloc,ins2snd2,mod2sng2,ss2stereo}.c`
 - 6510 player: `src/player*.s`, `src/altplayer*.s` (assembler: `src/asm/`)
@@ -16,8 +18,11 @@ C64 SID tracker (GoatTracker Stereo fork). ~32k LOC own logic; rest vendored/gen
 - `src/goatdata.c` is generated: never commit/edit; change packed inputs → follow `tests/docs/build-determinism.md`.
 - Do not modify vendored: `src/resid/`, `src/resid-fp/`, `src/asm/`, `src/RtMidi.*`, `src/bme/SDL/`.
 - Commits: single-line message; CHANGELOG carries the detail, updated only **after** the PR is ready to merge. New entries go under `[Unreleased]` — do not assign a version number until release.
-- Merge to `main` by **squash** only: `gh pr merge {PR} --squash --delete-branch`.
-- Both the **PR body** and the **squash merge commit body** must be exactly the single line `refer to CHANGELOG for details` — never duplicate CHANGELOG content in either.
-- No `Co-Authored-By` trailer on commits; no generated-by footer on PRs.
 - Do not bloat this file, leverage `## Index` above
+
+## Merge rules
+- Merge to `main` by **squash** only: `gh pr merge {PR} --squash --delete-branch`.
+- By default the **PR body** and the **squash merge commit body** are exactly the single line `refer to CHANGELOG for details` — never duplicate CHANGELOG content in either.
+- No `Co-Authored-By` trailer on commits; no generated-by footer on PRs.
+- **Exception — bulk-included contributions:** when a squash folds other contributors' work into a larger change (e.g. adopting or superseding their PRs), the squash-merge commit body extends beyond that single line to add (a) a concise one-line note of what was included, and (b) correct attribution — the commit `Author` for the primary contributor and/or `Co-authored-by:` trailers for each. Trailers are used only in this case.
 

--- a/src/ginfo.c
+++ b/src/ginfo.c
@@ -466,7 +466,7 @@ void displayPatternInfo(GTOBJECT *gt)
 				sprintf(infoTextBuffer, "Channel Tempo: %02X", (data - 0x80));
 		}
 		else
-			sprintf(infoTextBuffer, patternInstructionInfoString[instr]);
+			sprintf(infoTextBuffer, "%s", patternInstructionInfoString[instr]);
 	}
 	else
 		sprintf(infoTextBuffer, "                                ");

--- a/src/gpaletteeditor.c
+++ b/src/gpaletteeditor.c
@@ -619,8 +619,7 @@ void setPaletteName(char* paletteName, int index)
 	{
 		free(paletteNames[index]);
 	}
-	paletteNames[index] = malloc(strlen(paletteName));
-	strcpy(paletteNames[index], paletteName);	// copy filename. This is saved in the cfg file as the one to start up with
+	paletteNames[index] = strdup(paletteName);	// copy filename. This is saved in the cfg file as the one to start up with
 }
 
 int readPaletteData(char *paletteMem, char *paletteName)

--- a/src/gt2stereo.c
+++ b/src/gt2stereo.c
@@ -1195,14 +1195,14 @@ void waitkeymouse(GTOBJECT* gt)
 						else
 						{
 							sprintf(&keyOffsetText[0], "                        ");
-							sprintf(infoTextBuffer, keyOffsetText);
+							sprintf(infoTextBuffer, "%s", keyOffsetText);
 						}
 					}
 				}
 				else
 				{
 					calculateNoteOffsets();
-					sprintf(infoTextBuffer, keyOffsetText);
+					sprintf(infoTextBuffer, "%s", keyOffsetText);
 				}
 			}
 		}

--- a/src/makefile.common
+++ b/src/makefile.common
@@ -5,6 +5,21 @@ CXX?=g++
 CFLAGS+=-Ibme -Iasm -O3 -Wall -MMD -MP
 CXXFLAGS+=$(CFLAGS) -fpermissive
 
+# Sanitizer build: `make <plat>-build SANITIZE=1` (pair with a *-rebuild for a clean
+# slate, since object files are not keyed on their compile flags). SANFLAGS must reach
+# both the compile lines (CFLAGS/CXXFLAGS) and every link line (LDFLAGS), or the
+# ASan/UBSan runtime symbols go unresolved at link. Skip strip so reports keep symbols.
+STRIPCMD=strip
+ifeq ($(SANITIZE),1)
+# -D_FORTIFY_SOURCE=0: FORTIFY's __*_chk wrappers abort before ASan's interceptors can
+# report, so disable it under ASan to get symbolized diagnostics instead of a bare
+# "*** buffer overflow detected ***". (ASan/UBSan and FORTIFY are mutually antagonistic.)
+SANFLAGS=-fsanitize=address,undefined -fno-omit-frame-pointer -g -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0
+CFLAGS+=$(SANFLAGS)
+LDFLAGS+=$(SANFLAGS)
+STRIPCMD=true
+endif
+
 EXE=	$(PREFIX)gtultra$(SUFFIX) \
 	$(PREFIX)gt2reloc$(SUFFIX) \
 	$(PREFIX)ins2snd2$(SUFFIX) \
@@ -25,8 +40,8 @@ resid-fp/wavefp.o resid-fp/voicefp.o \
 asm/asmtab.o asm/chnkpool.o asm/expr.o asm/lexyy.o asm/log.o asm/membuf.o asm/membufio.o asm/namedbuf.o asm/parse.o \
 asm/pc.o asm/vec.o \
 bme/bme_gfx.o bme/bme_snd.o bme/bme_win.o bme/bme_mou.o bme/bme_kbd.o bme/bme_io.o bme/bme_end.o bme/bme.o
-	$(CXX) -o $@ $^ $(LIBS)
-	strip $@
+	$(CXX) $(LDFLAGS) -o $@ $^ $(LIBS)
+	$(STRIPCMD) $@
 
 
 # it would be nice not having to link things like resid, however the source is
@@ -41,20 +56,20 @@ resid-fp/wavefp.o resid-fp/voicefp.o \
 asm/asmtab.o asm/chnkpool.o asm/expr.o asm/lexyy.o asm/log.o asm/membuf.o asm/membufio.o asm/namedbuf.o asm/parse.o \
 asm/pc.o asm/vec.o \
 bme/bme_gfx.o bme/bme_snd.o bme/bme_win.o bme/bme_mou.o bme/bme_kbd.o bme/bme_io.o bme/bme_end.o bme/bme.o
-	$(CXX) -DGT2RELOC -o $@ $^ $(LIBS)
-	strip $@
+	$(CXX) $(LDFLAGS) -DGT2RELOC -o $@ $^ $(LIBS)
+	$(STRIPCMD) $@
 
 $(PREFIX)mod2sng2$(SUFFIX): mod2sng2.o bme/bme_end.o
-	$(CC) -o $@ $^
-	strip $@
+	$(CC) $(LDFLAGS) -o $@ $^
+	$(STRIPCMD) $@
 
 $(PREFIX)ins2snd2$(SUFFIX): ins2snd2.o bme/bme_end.o
-	$(CC) -o $@ $^
-	strip $@
+	$(CC) $(LDFLAGS) -o $@ $^
+	$(STRIPCMD) $@
 
 $(PREFIX)ss2stereo$(SUFFIX): ss2stereo.o bme/bme_end.o
-	$(CC) -o $@ $^
-	strip $@
+	$(CC) $(LDFLAGS) -o $@ $^
+	$(STRIPCMD) $@
 
 gt2stereo.dat: player.s altplayer.s player3.s altplayer3.s player9.s altplayer9.s player12.s altplayer12.s  0default.gtp 1default.gtp 2default.gtp 3default.gtp 4default.gtp 5default.gtp 6default.gtp 7default.gtp 8default.gtp chargen.bin palette.bin cursor.bin bcursor.bin goattrk2.bmp gt2stereo.seq
 	./bme/datafile $@ gt2stereo.seq

--- a/tests/docs/handover-asm-pointer-cast.md
+++ b/tests/docs/handover-asm-pointer-cast.md
@@ -1,0 +1,43 @@
+# Handover / tracking: PR #13 — `-Wpointer-to-int-cast` in `src/asm/`
+
+Tracking doc for GitHub **PR #13** (@drfiemost, "Fix pointer-to-int-cast warnings",
+**OPEN**, not merged). Surfaced by the warnings inventory
+([warnings-tracking.md](warnings-tracking.md)). Related: [known-bugs.md](known-bugs.md).
+
+## What PR #13 does
+Fixes all **11** `-Wpointer-to-int-cast` warnings, in **`src/asm/expr.c` (9)** and
+**`src/asm/parse.c` (2)**. It replaces `(u32)ptr` casts in `LOG()` debug-dump statements
+with `%p` + `(void*)ptr`:
+```c
+- LOG(level, ("expr 0x%08X symref %s\n", (u32)e, e->type.symref));
++ LOG(level, ("expr %p symref %s\n",      (void*)e, e->type.symref));
+```
+Sites: `expr_dump()` (expr.c) and `dump_sym_entry()` (parse.c).
+
+## Why it warns, and how serious it is
+On 64-bit, `(u32)e` **truncates** a 64-bit pointer to 32 bits — the warning is legitimate.
+But every site is inside a **debug `LOG()` dump helper**, so the only real-world effect is
+a wrong/truncated pointer value in debug log output. No program logic depends on the cast.
+- Practical severity: **LOW** (debug-only, cosmetic).
+- Fix correctness: **HIGH** and trivial (`%p`/`(void*)` is the canonical form).
+
+## Blocker: vendored-code policy (decision needed before adopting)
+`src/asm/` is listed in `CLAUDE.md` under **"Do not modify vendored"**. PR #13 patches it
+directly, so it cannot simply be merged without reconciling that rule:
+- **If `src/asm/` is an owned fork** (not tracking an upstream) → adopt PR #13 as-is,
+  credit @drfiemost, mark the pointer-to-int-cast row in `warnings-tracking.md` fixed.
+- **If it genuinely tracks upstream** → send the change upstream instead of merging here;
+  keep the vendored rule intact and leave these 11 warnings as accepted noise.
+
+This doc does **not** adopt PR #13 — it records it pending that call.
+
+## Steps to adopt (once the policy is decided)
+1. Branch from `main`.
+2. Apply PR #13 (fetch @drfiemost's branch, or apply the two-file diff).
+3. Rebuild; confirm the 11 `-Wpointer-to-int-cast` warnings are gone and no new warnings.
+4. CHANGELOG `### Fixed`: note the fix, "Thanks @drfiemost (PR #13)".
+5. Update [warnings-tracking.md](warnings-tracking.md) (11 → 0) and resolve this doc.
+
+## Definition of done
+0 `-Wpointer-to-int-cast` in the build; PR #13 closable; the `src/asm/` vendored-policy
+question explicitly resolved (owned-fork vs upstream).

--- a/tests/docs/handover-gt2reloc-bug2.md
+++ b/tests/docs/handover-gt2reloc-bug2.md
@@ -1,0 +1,46 @@
+# Handover: `gt2reloc` segfault (Bug 2) + `loadedsongfilename` overflow
+
+Pick-up doc. Bug 2 background in [known-bugs.md](known-bugs.md). Partly investigated while
+adding the ASan gate for issue #76 ([handover-issue-76.md](handover-issue-76.md)). Fresh
+branch from `main`.
+
+## Goal
+Make `gt2reloc` pack the fixture without crashing, and fix the ASan-found global overflow.
+
+## Two related defects (both in the `gt2reloc` tool)
+
+### Defect A — `loadedsongfilename` size mismatch (ASan global-buffer-overflow)
+- `goattrk2.h:117`: `extern char loadedsongfilename[MAX_PATHNAME]` (256).
+- `src/gt2stereo.c:136`: defines it `[MAX_PATHNAME]` (256) — correct (comment: "JP was
+  MAX_FILENAME").
+- **`src/gt2reloc.c:84`: defines it `[MAX_FILENAME]` (60)** — inconsistent with the extern.
+- `clearsong` (`src/gsong.c:1703`) does `memset(loadedsongfilename, 0, sizeof
+  loadedsongfilename)`; `sizeof` via the header is 256, so in the `gt2reloc` build it
+  memsets 256 bytes into a 60-byte global.
+- ASan (Linux, `SANITIZE=1`): `global-buffer-overflow WRITE of size 256 ... 0 bytes after
+  global 'loadedsongfilename' ... gt2reloc.c:84 ... in clearsong gsong.c:1703`, reached
+  from `gt2reloc.c:221` (main).
+- **Fix:** change `src/gt2reloc.c:84` to `char loadedsongfilename[MAX_PATHNAME];` (match the
+  extern; `MAX_FILENAME`=60, `MAX_PATHNAME`=256, both in `src/gfile.h`).
+
+### Defect B — the segfault itself (Bug 2, still unexplained)
+- `gt2reloc tests/fixtures/Stereo_Pendejo.sng out.prg` **segfaults (exit 139)** on Linux.
+- **VERIFIED:** applying Defect A's fix (`gt2reloc.c:84` -> `MAX_PATHNAME`) and clean
+  rebuilding, the pack **STILL segfaults (139)**. So Defect A is real but is **NOT** the
+  segfault root cause. Bug 2 has a separate/additional fault deeper in the packing path.
+
+## Steps
+1. Branch from `main`. Apply Defect A fix (`gt2reloc.c:84`).
+2. Build gt2reloc with `-g -O0 -fsanitize=address` and run the fixture pack to get a
+   symbolized stack trace at the ACTUAL fault (the packing path, past `clearsong`, not
+   startup). `make linux-rebuild SANITIZE=1` gives an ASan gt2reloc; also try `-O0`.
+3. Locate and fix the fault. Pin with a characterization test: fixture in -> assert exit 0
+   + non-empty `.prg`.
+4. Re-enable coverage now that gt2reloc is healthy:
+   - remove `SKIP_GT2RELOC: 1` from the build workflows (`.github/workflows/build-*.yml`);
+   - remove `SKIP_USAGE: 1` from the Linux ASan job (added for #76 to dodge Defect A).
+5. Update CHANGELOG `### Fixed`.
+
+## Definition of done
+- `gt2reloc` packs the fixture (exit 0, non-empty `.prg`); ASan clean on the CLI usage +
+  functional checks; `SKIP_GT2RELOC` / ASan-job `SKIP_USAGE` removed; smoke green on 3 OSes.

--- a/tests/docs/handover-unit-tests.md
+++ b/tests/docs/handover-unit-tests.md
@@ -1,0 +1,43 @@
+# Handover: bootstrap unit tests (sprout the palette-name helper)
+
+Pick-up doc. Rationale in [testing-strategy.md](testing-strategy.md) (ladder #3/#4).
+Motivated by issue #76 ([handover-issue-76.md](handover-issue-76.md)): the fix currently
+has only an integration/ASan gate, no unit test. Fresh branch from `main`.
+
+## Goal
+Stand up the project's first unit-test harness and add a regression unit test for the
+`setPaletteName` allocation contract (NUL-terminated, equal to input).
+
+## Why a sprout is needed (not just "link the .o")
+`setPaletteName` itself is trivial (touches only `char *paletteNames[16]` +
+`strdup`/`free`), but `src/gpaletteeditor.o` has **~58 external non-libc dependencies**
+(`drawbox`, `fliptoscreen`, `getColor`, `fileselector`, `getkey`, `mouse*`, editor
+globals, ...). Linking it into a test would require stubbing all of them — fragile.
+
+**Sprout instead** (testing-strategy ladder #4): extract the alloc/copy into a tiny pure
+helper with no editor/SDL deps, e.g.
+
+```c
+/* palette-name storage: allocate a NUL-terminated copy into slot `index`. */
+char *palette_name_dup(char **names, int index, const char *name);
+```
+
+Have `setPaletteName` call it. The helper links standalone into a unit test.
+
+## Steps
+1. Branch from `main`.
+2. Add a single-header harness (**Unity** or **greatest** — minimal deps, matches project
+   ethos; avoid GoogleTest/Criterion). Create `tests/unit/` + a `make test` target; wire
+   into the three build workflows.
+3. Sprout `palette_name_dup` (or similar) out of `setPaletteName`; keep `setPaletteName`
+   as a thin caller so production behaviour is unchanged.
+4. Unit test: call the helper with a known string; assert result is non-NULL, `strcmp`
+   equal, and `strlen`+1 bytes allocated (NUL present). Build the unit test under
+   `-fsanitize=address` so the old `malloc(strlen)` bug would fail it directly.
+5. (Optional, ladder #2) add golden/round-trip tests for the CLI tools while the harness
+   exists.
+6. Update CHANGELOG `### Added`.
+
+## Definition of done
+- `make test` runs a green unit suite (incl. the palette-name regression) locally and in
+  CI on at least Linux; test also passes under ASan.

--- a/tests/docs/handover-unused-result.md
+++ b/tests/docs/handover-unused-result.md
@@ -1,0 +1,52 @@
+# Handover: `-Wunused-result` cleanup sweep
+
+Pick-up doc. Surfaced while fixing issue #76 (see [known-bugs.md](known-bugs.md),
+[handover-issue-76.md](handover-issue-76.md)). Do on a fresh branch cut from `main`.
+
+## Goal
+Silence the 83 `-Wunused-result` warnings without regressing file I/O behaviour.
+
+## Background
+glibc marks `fread`/`fgets`/`fwrite`/`chdir`/`getcwd`/`write` with
+`__attribute__((warn_unused_result))` under `_FORTIFY_SOURCE` (active at `-O2`+, so at our
+`-O3`). Ignoring their return values warns. Counted on Linux (gcc 15/16):
+
+| function | count |
+|----------|-------|
+| `fread`  | 56    |
+| `fgets`  | 11    |
+| `write`  | 8     |
+| `chdir`  | 6     |
+| `getcwd` | 2     |
+| **total**| **83**|
+
+By file: `gsong.c` 36, `gsound.c` 9, `ss2stereo.c` 9, `gfile.c` 7, `ins2snd2.c` 5,
+`gconsole.c` 4, `io.c` 3, `gt2reloc.c` 2, `gpaletteeditor.c` 1.
+
+## Why this was deferred from #76
+Most of the count is `fread`/`write` inside **save/load paths** (`gsong.c`). Wrapping them
+wrong can silently corrupt or mask real I/O errors. It is a cross-cutting janitorial sweep,
+not a one-line fix, so it does not belong in a security-fix PR.
+
+## Approach (mechanical, do NOT bulk cast-to-void)
+- **A `(void)` cast does NOT silence `warn_unused_result`** in GCC — it still warns. So you
+  must actually consume the value.
+- Prefer **meaningful handling** where cheap: check `fread`/`fgets` element/char counts and
+  bail or log on short read; check `chdir`/`getcwd`/`write` for `-1` and handle.
+- Where a genuine ignore is intended, use a deliberate idiom that compiles clean, e.g.
+  `if (fread(...) != n) { /* handle/short-read */ }` or a small checked wrapper.
+- Do this **file by file**, rebuild after each, and diff behaviour. `gsong.c` (song
+  (de)serialisation) is the highest-risk file — pair with a golden/round-trip test
+  (testing-strategy ladder #2) before touching it if possible.
+
+## Steps
+1. Branch from `main`.
+2. Reproduce the list: `make linux-rebuild 2>&1 | grep -n unused-result` (or build under
+   FORTIFY on any platform). 83 expected.
+3. Fix per file, rebuild, confirm the count drops; run `tests/integration/smoke.sh`.
+4. For `gsong.c`, ideally add a `.sng` load->save->load byte-stability check first.
+5. Update CHANGELOG `### Fixed`.
+
+## Definition of done
+- 0 `-Wunused-result` warnings on Linux build; smoke tests green; no I/O regression
+  (round-trip stable).

--- a/tests/docs/known-bugs.md
+++ b/tests/docs/known-bugs.md
@@ -1,37 +1,16 @@
 # Task: Known functional bugs & their fixes
 
-Status: **identified, not yet fixed**
-Related: [build-determinism.md](build-determinism.md)
+This file tracks **open** functional bugs. Fixed ones move out (record lives in
+`CHANGELOG.md` + any `handover-*.md`). Related: [build-determinism.md](build-determinism.md).
 
 Approach for each: **pin behavior with a characterization/regression test FIRST**, then
 fix, so the fix is provably correct and stays fixed.
 
----
-
-## Bug 1 — Buffer overflow in `setPaletteName()` (GitHub issue #76)
-
-> Pick-up plan: [handover-issue-76.md](handover-issue-76.md). Credit: fix by @fgaz (PR #73), reported by @lunadog.
-
-- **Where:** `src/gpaletteeditor.c:616` `setPaletteName()`, defect at line 622.
-- **Defect:**
-  ```c
-  paletteNames[index] = malloc(strlen(paletteName));  // 1 byte too few (no NUL)
-  strcpy(paletteNames[index], paletteName);           // writes strlen+1 bytes
-  ```
-  A 1-byte heap overflow. glibc FORTIFY (`_FORTIFY_SOURCE`, active under `-O3`) detects it
-  and aborts: `*** buffer overflow detected ***: terminated` — the crash reported in #76.
-- **Status on `main`:** STILL PRESENT (verified). Both `main` and `resolve-PRs` at `d3bf412`.
-- **Fix:** replace with `strdup(paletteName)` (allocates strlen+1 and copies).
-  This is exactly **PR #73** ("Fix buffer overflow in setPaletteName()"), which is
-  **still OPEN / unmerged**; its fix did not make it into the 2nd-life tree.
-- **Test idea:** call `setPaletteName()` with a known string, assert the stored string is
-  NUL-terminated and equal; run the suite under ASan to catch the overflow directly.
-
-### Sub-item — format-security warnings (same issue #76 report)
-- `src/gt2stereo.c:1198` and `:1205`: `sprintf(infoTextBuffer, keyOffsetText);`
-  → `-Wformat-security` (format not a string literal). Fix: `sprintf(infoTextBuffer, "%s", keyOffsetText);`
-- Unchecked `chdir`/`fgets` return values (`-Wunused-result`) also still present.
-- Cosmetic (non-fatal) but cheap to clean up while touching the file.
+## Resolved (record only, no longer tracked here)
+- **issue #76** — heap buffer overflow in `setPaletteName()` (`src/gpaletteeditor.c`).
+  Fixed (`strdup`) + Linux ASan/UBSan CI gate. Details/credit: `CHANGELOG.md` and
+  [handover-issue-76.md](handover-issue-76.md). The same PR fixed 3 `-Wformat-security`
+  sites; the `-Wunused-result` sweep was deferred → [handover-unused-result.md](handover-unused-result.md).
 
 ---
 
@@ -41,10 +20,39 @@ fix, so the fix is provably correct and stays fixed.
 - **Symptom:** on the fixture `tests/fixtures/Stereo_Pendejo.sng` it segfaults during
   packing (`EXIT: 139` on macOS). Documented in `tests/README.md`.
 - **Status:** the functional smoke test is **kept blocking** so the regression stays
-  visible in CI.
-- **Next step:** reproduce, get a stack trace (build with `-fsanitize=address` /
-  `-g -O0`), locate the fault, pin with a characterization test on the fixture
-  (assert exit 0 + non-empty `.prg`), then fix.
+  visible in CI. Reproduced under ASan on Linux (Lima VM): still segfaults (exit 139).
+- **ASan finding (partial, does NOT fix the segfault):** `clearsong` (`src/gsong.c:1703`)
+  does `memset(loadedsongfilename, 0, sizeof loadedsongfilename)`. The header extern
+  (`goattrk2.h:117`) and `gt2stereo.c:136` declare `loadedsongfilename[MAX_PATHNAME]`
+  (256), but **`gt2reloc.c:84` declares it `[MAX_FILENAME]` (60)** — so in the gt2reloc
+  build `clearsong` memsets 256 bytes into a 60-byte global → ASan `global-buffer-overflow`
+  (`WRITE of size 256 ... 0 bytes after 'loadedsongfilename'`, via `gt2reloc.c:221`).
+  **Verified:** changing `gt2reloc.c:84` to `MAX_PATHNAME` silences this overflow but the
+  gt2reloc pack **still segfaults (139)** — so this is a real, separate defect but NOT the
+  segfault root cause. Deferred to the Bug-2 / unused-result follow-up.
+- **Next step:** get a full stack trace at the actual fault (build `-g -O0` +ASan), locate
+  it, pin with a characterization test on the fixture (assert exit 0 + non-empty `.prg`),
+  then fix. Also apply the `gt2reloc.c:84` size fix and re-widen the ASan job to the CLI
+  usage checks (currently `SKIP_USAGE=1` there to avoid this pre-existing overflow).
+  Full pick-up plan: [handover-gt2reloc-bug2.md](handover-gt2reloc-bug2.md).
+
+---
+
+## Bug 3 — high idle CPU on macOS Apple Silicon (GitHub issue #85)
+
+- **Where:** `gtultra` interactive editor (main loop), macOS on Apple Silicon (M-series).
+- **Symptom:** "can easily take 40%+ on an idle editor" — high CPU with no user activity.
+- **Status:** OPEN, root cause not yet confirmed.
+- **Likely cause (to verify):** a busy render/input loop with no blocking wait or frame
+  throttle. The editor loops `fliptoscreen(); getkey();` (e.g. `gt2stereo.c` main loop,
+  `gpaletteeditor.c:275`) — if input is polled non-blocking and the frame is redrawn every
+  iteration without vsync or an `SDL_Delay`/`SDL_WaitEvent`, the thread spins at 100% of a
+  core. Retina/HiDPI redraw cost on Apple Silicon may amplify it.
+- **Next step:** profile idle with `sample`/Instruments (Time Profiler) to find the hot
+  loop; check the BME/SDL event path (`src/bme/bme_*.c`) for polling vs blocking and
+  whether vsync / a frame cap is applied. Fix by yielding when idle (blocking event wait
+  or a small delay) without harming playback timing. Pin with a manual CPU-usage check;
+  this is not currently covered by smoke tests (interactive).
 
 ---
 

--- a/tests/docs/testing-strategy.md
+++ b/tests/docs/testing-strategy.md
@@ -24,8 +24,9 @@ does NOT mean a rewrite.
 
 ## Priority ladder (highest ROI first)
 1. **ASan/UBSan CI build** running `smoke.sh`. Compile with
-   `-fsanitize=address,undefined`. Would have caught issue #76 automatically with a stack
-   trace. ~1h of Makefile/CI work; do this first.
+   `-fsanitize=address,undefined`. **DONE** (issue #76): `make <plat>-build SANITIZE=1`
+   (`src/makefile.common`) + a Linux job in `build-linux.yml`. Caught #76 with a symbolized
+   trace. See [handover-issue-76.md](handover-issue-76.md) and the coverage note below.
 2. **Golden-file / round-trip tests** on the non-interactive CLI tools
    (`gt2reloc`, `mod2sng2`, `ins2snd2`): feed a fixture, assert stable output
    (hash/size). Add a `.sng` load->save->load byte-stability check. No refactor needed.
@@ -33,6 +34,30 @@ does NOT mean a rewrite.
    `known-bugs.md`.
 4. **Extract pure domain functions** (reloc math in `greloc.c`, table-index/undo logic,
    packing helpers) out of the god-modules via sprout/wrap, and unit-test those.
+
+## Sanitizer platform coverage (Linux-only gate, and why)
+The ASan/UBSan gate runs on **Linux only**. This was decided from evidence, not
+convenience; do not "add the other platforms" without re-reading this.
+- **Linux (gcc):** full ASan+UBSan, and it reproduces #76 exactly (glibc FORTIFY abort +
+  symbolized ASan trace, headless). This is the real gate.
+- **macOS (Apple clang):** ASan+UBSan exist and a standalone control catches the exact
+  `malloc(strlen)+strcpy` pattern, BUT the instrumented `gtultra` reaches the Cocoa event
+  loop without firing (startup overflow path not exercised the way Linux does; root cause
+  undetermined — likely the SDL/Cocoa `main` shim or allocator path). Also no FORTIFY and a
+  16-byte min malloc bucket, so a normal build never crashes. **A mac ASan job would be
+  GREEN with the bug present → not a valid gate.** macOS stays normal build+smoke.
+- **Windows:** MinGW-w64 GCC (current CI) ships **no libasan** (`--disable-libsanitizer`;
+  `cannot find -lasan`); UBSan only in diagnostic-less trap mode. MSVC has ASan but **never
+  UBSan**, and needs a full Makefile→MSBuild + source port. MSYS2 CLANG64 has both but
+  forces a whole-toolchain migration (libc++/UCRT ABI rebuild of all C++, fix
+  `-fpermissive`-masked code, drop `-static`+`strip`, PATH the asan runtime DLL). All are
+  costly/lower-coverage. Windows stays normal build+smoke.
+- Cheap optional extra (not done): `-fsanitize=undefined -fsanitize-trap=undefined
+  -fno-sanitize-recover=all` on the existing MinGW job gives diagnostic-less UB-crash
+  coverage with no runtime.
+
+Bottom line: ASan/UBSan catch language-level, platform-independent defects, so one Linux
+build catches the overwhelming majority. Spend effort on Linux depth, not OS breadth.
 
 ## Framework
 Single-header C harness (**Unity** or **greatest**). Add `tests/unit/` + a `make test`

--- a/tests/docs/warnings-tracking.md
+++ b/tests/docs/warnings-tracking.md
@@ -1,0 +1,65 @@
+# Compiler warnings tracking
+
+Inventory of build warnings, to triage and burn down over time. **Not fixed in the
+issue-#76 iteration** — this doc just records the current state so it is not lost.
+Related: [handover-unused-result.md](handover-unused-result.md),
+[testing-strategy.md](testing-strategy.md), [known-bugs.md](known-bugs.md).
+
+## Source / how to regenerate
+From a full Linux build under `-Wall -O3` (GCC 16, as in CI `build-linux.yml`):
+```
+make linux-rebuild 2>&1 | tee /tmp/build.log
+grep -oE '\[-W[a-z0-9-]+\]' /tmp/build.log | sort | uniq -c | sort -rn   # by type
+grep -n 'warning:' /tmp/build.log                                        # full list
+```
+Snapshot below is from the GCC-16 CI build (one leg): ~159 `warning:` lines.
+
+## By type
+| warning | count | notes |
+|---------|-------|-------|
+| `-Wunused-result` | 83 | `fread`/`fgets`/`write`/`chdir`/`getcwd` return values ignored. Dedicated sweep: [handover-unused-result.md](handover-unused-result.md) |
+| `-Wpointer-to-int-cast` | 11 | vendored `src/asm/` (`expr.c` ×9, `parse.c` ×2). Existing fix: **PR #13** — see [handover-asm-pointer-cast.md](handover-asm-pointer-cast.md) |
+| `-Wparentheses` | 6 | vendored |
+| `-Wunused-function` | 3 | vendored |
+| `-Wmaybe-uninitialized` | 2 | vendored (`resid`/`bme`) |
+| `-Wuninitialized` | 2 | vendored |
+| `-Wunused-variable` | 1 | own: `src/greloc.c:156` (`temppackedsongname` unused) — cosmetic |
+| `-Wunused-value` | 1 | vendored |
+| `-Wstringop-truncation` | 1 | own: `src/gt2stereo.c:2972` — see below |
+
+## Own-code vs vendored
+Vendored (**do NOT modify** per `CLAUDE.md`: `src/asm/`, `src/resid/`, `src/resid-fp/`,
+`src/bme/`, `src/RtMidi.*`) accounts for **every** potentially-serious class
+(`pointer-to-int-cast`, `uninitialized`, `maybe-uninitialized`, `parentheses`,
+`unused-function`, `unused-value`). Those are upstream engine/parser warnings; leave them.
+
+**Own code** (`src/g*.c`, CLI tools) warnings are almost entirely `-Wunused-result`
+(deferred sweep). The only two own-code, non-`unused-result` warnings are:
+
+1. **`src/greloc.c:156` — `-Wunused-variable`** (`char temppackedsongname[MAX_FILENAME];`
+   declared, never used). Trivial: delete the declaration. Cosmetic.
+2. **`src/gt2stereo.c:2972` — `-Wstringop-truncation`** — and this one deserves a look, it
+   may be a latent heap overflow:
+   ```c
+   name = malloc(4);
+   strncpy(name, specialnotenames + j, 2);   // 2 bytes, no NUL
+   sprintf(octave, "%d", oct);
+   strcpy(name + 2, octave);                 // writes strlen(octave)+1 at name+2
+   ```
+   The 4-byte buffer fits a single-digit octave (2 note chars + 1 digit + NUL = 4), but a
+   **two-digit `oct` (>= 10) overflows** (2 + 2 + 1 = 5 > 4). Confirm the octave range
+   (custom tunings / `equaldivisionsperoctave` may exceed 9); if reachable, size the
+   allocation properly. Track/verify like the other memory bugs (ASan).
+
+## Priority
+1. `src/gt2stereo.c:2972` — verify the octave range; fix if a 2-digit octave is reachable
+   (potential heap overflow, same class as issue #76).
+2. `-Wunused-result` sweep — [handover-unused-result.md](handover-unused-result.md).
+3. `src/greloc.c:156` — delete the unused variable (cosmetic).
+4. Vendored warnings — out of scope (do not modify vendored trees), EXCEPT the 11
+   `-Wpointer-to-int-cast` in `src/asm/`, which have a ready fix in PR #13 pending a
+   vendored-policy call → [handover-asm-pointer-cast.md](handover-asm-pointer-cast.md).
+
+## Note on this iteration
+The issue-#76 PR **removed** 3 `-Wformat-security` warnings and **adds none**; the counts
+above are pre-existing on `main` (not introduced here).

--- a/tests/integration/smoke.sh
+++ b/tests/integration/smoke.sh
@@ -100,15 +100,33 @@ fi
 
 if [ "$SKIP_GTULTRA" -eq 0 ]; then
   echo -e "\n=== gtultra startup smoke test ==="
+  gtultra_err=$(mktemp)
   set +e
-  run_with_timeout 5 "$GTULTRA" -? >/dev/null 2>&1
+  run_with_timeout 5 "$GTULTRA" -? >/dev/null 2>"$gtultra_err"
   gtultra_ec=$?
   set -e
-  if [ "$gtultra_ec" -eq 139 ] || [ "$gtultra_ec" -eq 138 ]; then
+  # A healthy headless startup runs until the timeout kills it (124 from `timeout`,
+  # 143 from the SIGTERM fallback) or exits cleanly (0). Fatal-signal exit codes (128+N)
+  # mean a real crash: 134=SIGABRT (glibc FORTIFY / ASan abort), 139=SIGSEGV, 138=SIGBUS,
+  # 136=SIGFPE, 132=SIGILL (e.g. UBSan trap). (137=SIGKILL is intentionally NOT treated as
+  # a crash: no timeout path here produces it, but --kill-after/OOM could -> avoid false
+  # fails.) Also scan stderr for sanitizer / FORTIFY diagnostics, which can print without a
+  # fatal exit code (Linux ASan defaults to exit 1, not abort). This is what catches #76.
+  gtultra_crash=0
+  case "$gtultra_ec" in
+    132|134|135|136|138|139) gtultra_crash=1 ;;
+  esac
+  if grep -qiE 'AddressSanitizer|UndefinedBehaviorSanitizer|runtime error:|buffer overflow detected|stack smashing detected' "$gtultra_err"; then
+    gtultra_crash=1
+  fi
+  if [ "$gtultra_crash" -ne 0 ]; then
     report 1 "gtultra crashed on startup (exit $gtultra_ec)"
+    echo "--- gtultra stderr (first 25 lines) ---" >&2
+    sed -n '1,25p' "$gtultra_err" >&2
   else
     report 0 "gtultra starts without crashing (exit $gtultra_ec)"
   fi
+  rm -f "$gtultra_err"
 else
   echo -e "\n=== Skipping gtultra startup smoke test ==="
 fi


### PR DESCRIPTION
refer to CHANGELOG for details

Authored by @marcinkubica (Linux ASan/UBSan CI gate for #76 + follow-up tracking docs); bulk-includes @fgaz's setPaletteName strdup fix (PR #73) and @OPNA2608's -Wformat-security fixes (PR #22).

Closes #76
Supersedes #73, #22

Co-authored-by: Francesco Gazzetta <fgaz@fgaz.me>
Co-authored-by: OPNA2608 <christoph.neidahl@gmail.com>
Reported-by: lunadog <4701502+lunadog@users.noreply.github.com>